### PR TITLE
iOS Fix: Map sessionType Enum correctly

### DIFF
--- a/ios/Classes/SwiftFlutterInfonlineLibraryPlugin.swift
+++ b/ios/Classes/SwiftFlutterInfonlineLibraryPlugin.swift
@@ -113,6 +113,6 @@ public class SwiftFlutterInfonlineLibraryPlugin: NSObject, FlutterPlugin {
   }
 
   private func stringToEnumValue(_ value: String, values: [String]) -> UInt {
-      return UInt(values.firstIndex(where: {$0 == value}) ?? 0)
+      return UInt(values.firstIndex(where: {$0 == value.uppercased()}) ?? 0)
   }
 }


### PR DESCRIPTION
In iOS, the enum value "oewa" isn't mapped correctly to the official iOS SDK's "OEWA" value - this PR fixes that

Note: This PR doen't contain a version bump (yet)