### PR TITLE
Replace gms:play-services-ads dependency with gms:play-services-ads-identifier

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     // Fix crash in INFOnline Library
     implementation 'androidx.preference:preference-ktx:1.1.1'
     // INFOnline Library requires only the advertisement identifier
-    implementation 'com.google.android.gms:play-services-ads-identifier:18.2.0'
+    implementation 'com.google.android.gms:play-services-ads-identifier:18.1.0'
     // Link the INFOnline Library
     implementation 'de.infonline.lib:infonlinelib_2.5.0@aar'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,8 +56,8 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version'
     // Fix crash in INFOnline Library
     implementation 'androidx.preference:preference-ktx:1.1.1'
-    // INFOnline Library benötigt die Mobile Ads API der Google Play Services Library
-    implementation 'com.google.android.gms:play-services-ads:21.5.0'
-    // Die INFONline Library verlinken
+    // INFOnline Library requires only the advertisement identifier
+    implementation 'com.google.android.gms:play-services-ads-identifier:18.2.0'
+    // Link the INFOnline Library
     implementation 'de.infonline.lib:infonlinelib_2.5.0@aar'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -68,8 +68,4 @@ flutter {
 }
 
 dependencies {
-    // INFOnline Library benötigt die Mobile Ads API der Google Play Services Library
-    implementation 'com.google.android.gms:play-services-ads:22.6.0'
-    // Die INFONline Library verlinken
-    implementation 'de.infonline.lib:infonlinelib_2.5.0@aar'
 }


### PR DESCRIPTION
Closes #5. 
The gms:play-services-ads version used was sunset and causes issues on Google Play release. Further investigation revealed that the infonline-measurement only uses it for the advertising id (https://docs.infonline.de/infonline-measurement/integration/lib/android/pseudonym/android_pseudonym_playstore/), which for some time has had its own dependency (split from play-services-ads). 

Thus we are replacing the general gms:play-service-ads dependency with gms:play-services-ads-identifier.

Tested it and it was still able to send events successfully, also including the advertising id. 
Using 18.1.0 for best compatibility.